### PR TITLE
use new version of mkdirp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/ads-service-downloader",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Download a file and decompress it. Designed for use with Azure Data Studio",
   "main": "out/main.js",
   "typings": "out/main",
@@ -15,7 +15,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/async-retry": "^1.4.1",
-    "@types/mkdirp": "^0.5.1",
+    "@types/mkdirp": "1.0.2",
     "@types/mocha": "^5.2.5",
     "@types/node": "^9.4.6",
     "@types/rimraf": "^2.0.2",
@@ -34,7 +34,7 @@
     "eventemitter2": "^5.0.1",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.3",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "1.0.4",
     "tar": "^6.1.11",
     "tmp": "^0.0.33",
     "yauzl": "^2.10.0"

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -5,15 +5,13 @@
 
 import { open as _openZip, Entry, ZipFile } from 'yauzl';
 import * as path from 'path';
-import * as _mkdirp from 'mkdirp';
+import * as mkdirp from 'mkdirp';
 import { Sequencer } from './async';
 import { Readable } from 'stream';
 import { WriteStream, createWriteStream } from 'fs';
-import { promisify } from 'util';
 import { EventEmitter2 as EventEmitter } from 'eventemitter2';
 import { Events } from './interfaces';
 
-const mkdirp = promisify(_mkdirp);
 
 export type ExtractErrorType = 'CorruptZip' | 'Incomplete';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,10 +51,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/mkdirp@^0.5.1":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.5.2.tgz#503aacfe5cc2703d5484326b1b27efa67a339c1f"
-  integrity sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
+"@types/mkdirp@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-1.0.2.tgz#8d0bad7aa793abe551860be1f7ae7f3198c16666"
+  integrity sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==
   dependencies:
     "@types/node" "*"
 
@@ -448,6 +448,11 @@ mkdirp@0.5.1, mkdirp@^0.5.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+mkdirp@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mkdirp@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
the new version of mkdirp doesn't have dependency on minimist package anymore. but other packages in devDependencies still requires minimist which is not something we need to concern.