### PR TITLE
update OSX runtime display name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/ads-service-downloader",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Download a file and decompress it. Designed for use with Azure Data Studio",
   "main": "out/main.js",
   "typings": "out/main",

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -241,8 +241,9 @@ export function getRuntimeDisplayName(runtime: Runtime): string {
         case Runtime.Windows:
             return 'Windows';
         case Runtime.OSX:
-        case Runtime.OSX_ARM64:
             return 'OSX';
+        case Runtime.OSX_ARM64:
+            return 'OSX_ARM64';
         case Runtime.CentOS:
         case Runtime.Debian:
         case Runtime.ElementaryOS_0_3:


### PR DESCRIPTION
We need to be able to bundle the STS for both x64 and ARM64 together when building the Universal package for macOS. By making this change, at runtime, the service downloader can load the correct STS based on the OS architecture.